### PR TITLE
Small, medium and big changes to the final version of app

### DIFF
--- a/conferecebook/lib/CommentsPage.dart
+++ b/conferecebook/lib/CommentsPage.dart
@@ -158,44 +158,92 @@ class CommentsPageState extends State<CommentsPage> {
         child: ListTile(
       leading: InkWell(
           onTap: () async {
-            FirebaseDatabase.instance
-                .reference()
-                .once()
-                .then((DataSnapshot snapshot) {
-              Map<dynamic, dynamic> map = snapshot.value;
-              Navigator.of(context).pushReplacement(MaterialPageRoute(
-                  builder: (context) => ViewProfile1(
-                      auth: widget.auth,
-                      userToSee: userUID,
-                      map: map,
-                      code: widget.code)));
-            });
+            if (auth.currentUser.uid == userUID) {
+              FirebaseDatabase.instance
+                  .reference()
+                  .once()
+                  .then((DataSnapshot snapshot) {
+                Map<dynamic, dynamic> map = snapshot.value;
+                String user = auth.currentUser.uid;
+                String image = map.values.toList()[2][user]["photo"];
+                String name = map.values.toList()[2][user]["name"];
+                String job = map.values.toList()[2][user]["job"];
+                String interests = map.values.toList()[2][user]["interests"];
+                String city = map.values.toList()[2][user]["city"];
+                String bio = map.values.toList()[2][user]["bio"];
+                String area = map.values.toList()[2][user]["area"];
+                String linkedin = map.values.toList()[2][user]["linkedin"];
+                String facebook = map.values.toList()[2][user]["facebook"];
+                String instagram = map.values.toList()[2][user]["instagram"];
+                String twitter = map.values.toList()[2][user]["twitter"];
+                String github = map.values.toList()[2][user]["github"];
+                Navigator.push(context, MaterialPageRoute(
+                    builder: (context) => MyProfile1(
+                        auth: auth,
+                        image: image,
+                        name: name,
+                        job: job,
+                        interests: interests,
+                        city: city,
+                        bio: bio,
+                        area: area,
+                        linkedin: linkedin,
+                        facebook: facebook,
+                        instagram: instagram,
+                        twitter: twitter,
+                        github: github,
+                        code: code)));
+              });
+            } else {
+              FirebaseDatabase.instance
+                  .reference()
+                  .once()
+                  .then((DataSnapshot snapshot) {
+                Map<dynamic, dynamic> map = snapshot.value;
+
+                Navigator.push(context, MaterialPageRoute(
+                    builder: (context) => ViewProfile1(
+                        auth: widget.auth,
+                        userToSee: userUID,
+                        map: map,
+                        code: widget.code)));
+              });
+            }
           },
           child: CircleAvatar(
             radius: 20.0,
             backgroundImage: NetworkImage(userPhoto),
             //default image
           )),
-      subtitle: Text(comment),
-      title: Row(mainAxisAlignment: MainAxisAlignment.spaceBetween, children: <
-          Widget>[
-        Text(name),
-        Text(
-          checkSameDay(commentID),
-          style: new TextStyle(
-            fontSize: 10.0,
-            color: Colors.grey,
-          ),
-        ),
-        if (userRole == "Organizer")
-          Transform.scale(
-              scale: 0.8,
-              child: IconButton(
+      subtitle: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: <Widget>[
+            Container(
+              width: 200,
+                child: Text(comment)),
+            if (userRole == "Organizer")
+              IconButton(
                   icon: Icon(FontAwesomeIcons.times, color: Color(0xff8d0000)),
                   onPressed: () {
                     showDeleteDialog(context, commentID);
-                  })),
-      ]),
+                  })
+          ]),
+      title: Stack(
+        children: <Widget>[
+          Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: <Widget>[
+                Text(name),
+                Text(
+                  checkSameDay(commentID),
+                  style: new TextStyle(
+                    fontSize: 10.0,
+                    color: Colors.black45,
+                  ),
+                ),
+              ]),
+        ],
+      ),
       isThreeLine: true,
     ));
   }

--- a/conferecebook/lib/ConferenceHistory.dart
+++ b/conferecebook/lib/ConferenceHistory.dart
@@ -186,7 +186,7 @@ class _ConferenceHistoryState extends State<ConferenceHistory> {
                     //initial value
                     value: this.showConferenceHistory,
                     textOn: 'Allowed',
-                    textOff: 'No',
+                    textOff: 'Blocked',
                     colorOn: Color(0xff1A2677),
                     colorOff: Colors.black54,
                     iconOn: Icons.done,

--- a/conferecebook/lib/CreateProfile1.dart
+++ b/conferecebook/lib/CreateProfile1.dart
@@ -167,7 +167,6 @@ class _CreateProfile1 extends State<CreateProfile1> {
     }
   }
 
-  final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
   final TextEditingController _emailController = TextEditingController();
   final TextEditingController _passwordController = TextEditingController();
 
@@ -183,29 +182,21 @@ class _CreateProfile1 extends State<CreateProfile1> {
   Widget build(BuildContext context) {
     auth = widget.auth;
     return Scaffold(
-        resizeToAvoidBottomPadding: false,
-        appBar: AppBar(
-          title: Text("New Account"),
-          backgroundColor: const Color(0xff1A2677),
-        ),
         body: Stack(
           children: <Widget>[
+            Container(),
+            Container(),
             Transform.translate(
               offset: Offset(SizeConfig.screenWidth * 164.0,
-                  SizeConfig.screenHeight * 50.0),
+                  SizeConfig.screenHeight * 134.0),
               child: Image.asset(
                 'images/icon.png',
-                width: SizeConfig.screenWidth * 90.0,
+                width: 90.0,
               ),
             ),
-            Form(
-              key: _formKey,
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: <Widget>[
                   Transform.translate(
                     offset: Offset(SizeConfig.screenWidth * 53.5,
-                        SizeConfig.screenHeight * 300.0),
+                        SizeConfig.screenHeight * 400.0),
                     child: Container(
                       width: 270.0,
                       child: TextFormField(
@@ -233,7 +224,7 @@ class _CreateProfile1 extends State<CreateProfile1> {
                   ),
                   Transform.translate(
                       offset: Offset(SizeConfig.screenWidth * 53.5,
-                          SizeConfig.screenHeight * 150.0),
+                          SizeConfig.screenHeight * 300.0),
                       child: Container(
                         width: 270.0,
                         child: TextFormField(
@@ -259,14 +250,38 @@ class _CreateProfile1 extends State<CreateProfile1> {
                         ),
                       )),
                   Transform.translate(
-                    offset: Offset(SizeConfig.screenWidth / 2,
-                        SizeConfig.screenHeight * 300.0),
-                    child: Container(
-                      padding: const EdgeInsets.symmetric(vertical: 16.0),
-                      alignment: Alignment.center,
+                    offset: Offset(SizeConfig.screenWidth * 132.0,
+                        SizeConfig.screenHeight * 504.0),
+                    child: SizedBox(
+                      width: 149.0,
+                      height: 57.0,
+                      child: Stack(
+                        children: <Widget>[
+                          Pinned.fromSize(
+                            bounds: Rect.fromLTWH(0.0, 0.0, 149.0, 57.0),
+                            size: Size(149.0, 57.0),
+                            pinLeft: true,
+                            pinRight: true,
+                            pinTop: true,
+                            pinBottom: true,
+                            child: Container(
+                              decoration: BoxDecoration(
+                                borderRadius: BorderRadius.circular(35.0),
+                                color: const Color(0xff1A2677),
+                                border: Border.all(
+                                    width: 1.0, color: const Color(0xff1A2677)),
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                  Transform.translate(
+                      offset: Offset(SizeConfig.screenWidth * 133,
+                          SizeConfig.screenHeight * 520.0),
                       child: InkWell(
-                        onTap: () async {
-                          if (_formKey.currentState.validate()) {
+                        onTap: () {
                             _register().then((value) {
                               if ((this.email == "") || (this.password == "")) {
                                 showAlertDialog0(context);
@@ -283,69 +298,38 @@ class _CreateProfile1 extends State<CreateProfile1> {
                                             auth: auth, userId: userId)));
                               }
                             });
-                          }
                         },
                         child: SizedBox(
-                          width: 149.0,
-                          height: 57.0,
-                          child: Stack(
-                            children: <Widget>[
-                              Pinned.fromSize(
-                                bounds: Rect.fromLTWH(0.0, 0.0, 149.0, 57.0),
-                                size: Size(149.0, 57.0),
-                                pinLeft: true,
-                                pinRight: true,
-                                pinTop: true,
-                                pinBottom: true,
-                                child: Container(
-                                  decoration: BoxDecoration(
-                                    borderRadius: BorderRadius.circular(35.0),
-                                    color: const Color(0xff1A2677),
-                                    border: Border.all(
-                                        width: 1.0,
-                                        color: const Color(0xff1A2677)),
-                                  ),
-                                  child: SizedBox(
-                                    width: 88.0,
-                                    child: Text(
-                                      'REGISTER',
-                                      style: TextStyle(
-                                        fontFamily: 'Roboto',
-                                        fontSize: 20,
-                                        color: const Color(0xffffffff),
-                                        letterSpacing: 1.6909999999999998,
-                                        height: 2,
-                                      ),
-                                      textAlign: TextAlign.center,
-                                    ),
-                                  ),
-                                ),
-                              ),
-                            ],
+                          width: 150.0,
+                          child: Text(
+                            'REGISTER',
+                            style: TextStyle(
+                              fontFamily: 'Roboto',
+                              fontSize: 25,
+                              color: const Color(0xffffffff),
+                              letterSpacing: 1.6909999999999998,
+                              height: 1.2,
+                            ),
+                            textAlign: TextAlign.center,
                           ),
                         ),
-                      ),
-                    ),
+                      )),
+            Transform.translate(
+              offset: Offset(SizeConfig.screenWidth * 135.0,
+                  SizeConfig.screenHeight * 829.0),
+              child: SizedBox(
+                width: SizeConfig.screenWidth * 144.0,
+                child: Text(
+                  'ConferenceBook',
+                  style: TextStyle(
+                    fontFamily: 'Roboto',
+                    fontSize: 16,
+                    color: const Color(0xff1A2677),
+                    letterSpacing: 0.15,
+                    height: SizeConfig.screenHeight * 1.5,
                   ),
-                  Transform.translate(
-                    offset: Offset(SizeConfig.screenWidth * 135.0,
-                        SizeConfig.screenHeight * 460.0),
-                    child: SizedBox(
-                      width: SizeConfig.screenWidth * 144.0,
-                      child: Text(
-                        'ConferenceBook',
-                        style: TextStyle(
-                          fontFamily: 'Roboto',
-                          fontSize: 16,
-                          color: const Color(0xff1A2677),
-                          letterSpacing: 0.15,
-                          height: SizeConfig.screenHeight * 1.5,
-                        ),
-                        textAlign: TextAlign.center,
-                      ),
-                    ),
-                  ),
-                ],
+                  textAlign: TextAlign.center,
+                ),
               ),
             ),
           ],

--- a/conferecebook/lib/EditProfile.dart
+++ b/conferecebook/lib/EditProfile.dart
@@ -74,7 +74,6 @@ class EditProfile1 extends StatefulWidget {
 }
 
 class _EditProfile1 extends State<EditProfile1> {
-  String image;
   String interests;
   String facebook;
   String instagram;
@@ -83,11 +82,6 @@ class _EditProfile1 extends State<EditProfile1> {
   String github;
   String code;
   FirebaseAuth auth;
-  String name;
-  String job;
-  String city;
-  String bio;
-  String area;
 
   TextEditingController bioController;
   TextEditingController jobController;
@@ -184,13 +178,13 @@ class _EditProfile1 extends State<EditProfile1> {
           Navigator.of(context).pushReplacement(MaterialPageRoute(
               builder: (context) => MyProfile1(
                   auth: auth,
-                  image: image,
-                  name: name,
-                  job: job,
+                  image: widget.image,
+                  name: widget.name,
+                  job: widget.job,
                   interests: interests,
-                  city: city,
-                  bio: bio,
-                  area: area,
+                  city: widget.city,
+                  bio: widget.bio,
+                  area: widget.area,
                   linkedin: linkedin,
                   facebook: facebook,
                   instagram: instagram,
@@ -265,7 +259,7 @@ class _EditProfile1 extends State<EditProfile1> {
       Navigator.of(context).pushReplacement(MaterialPageRoute(
           builder: (context) => MyProfile1(
               auth: auth,
-              image: image,
+              image: widget.image,
               name: nameController.value.text,
               job: jobController.value.text,
               interests: interests,
@@ -281,12 +275,32 @@ class _EditProfile1 extends State<EditProfile1> {
     }
   }
 
+  showAlertDialog(BuildContext context) async {
+    return showDialog(
+        context: context,
+        builder: (context) {
+          return AlertDialog(
+              title: Text('Empty Name'),
+              content:
+                  Text('The field name is empty. Please fill it with a name.'),
+              actions: <Widget>[
+                new FlatButton(
+                    child: new Text('Ok'),
+                    onPressed: () {
+                      Navigator.of(context).pop();
+                    }),
+              ]);
+        });
+  }
+
   @override
   void initState() {
     super.initState();
     bioController = TextEditingController(text: widget.bio);
     jobController = TextEditingController(text: widget.job);
-    areaController = TextEditingController(text: widget.area);
+    areaController = widget.area.trimRight().isEmpty
+        ? TextEditingController(text: "")
+        : TextEditingController(text: widget.area);
     nameController = TextEditingController(text: widget.name);
     cityController = TextEditingController(text: widget.city);
   }
@@ -305,7 +319,6 @@ class _EditProfile1 extends State<EditProfile1> {
   Widget build(BuildContext context) {
     SizeConfig().init(context);
     auth = widget.auth;
-    image = widget.image;
     interests = widget.interests;
     facebook = widget.facebook;
     instagram = widget.instagram;
@@ -313,11 +326,6 @@ class _EditProfile1 extends State<EditProfile1> {
     twitter = widget.twitter;
     github = widget.github;
     code = widget.code;
-    name = widget.name;
-    city = widget.city;
-    area = widget.area;
-    job = widget.job;
-    bio = widget.bio;
     final bottom = MediaQuery.of(context).viewInsets.bottom;
     return WillPopScope(
         onWillPop: () async => false,
@@ -328,7 +336,11 @@ class _EditProfile1 extends State<EditProfile1> {
                 padding: EdgeInsets.only(top: 52.0, right: 0.0),
                 child: FloatingActionButton(
                   onPressed: () {
-                    updateDataBase(context);
+                    if (nameController.value.text.trimRight().isEmpty) {
+                      showAlertDialog(context);
+                    } else {
+                      updateDataBase(context);
+                    }
                   },
                   backgroundColor: const Color(0xff1A2677),
                   child: Icon(
@@ -367,55 +379,153 @@ class _EditProfile1 extends State<EditProfile1> {
               ),
               Transform.translate(
                 offset: Offset(SizeConfig.screenWidth * 79,
-                    SizeConfig.screenHeight * 320.0),
+                    SizeConfig.screenHeight * 310.0),
                 child: SizedBox(
                     width: SizeConfig.screenWidth * 260.0,
                     child: Container(
                       width: 260,
-                      height: 20,
-                      child: TextField(
-                        controller: cityController,
-                        onChanged: (String value) async {
-                          city = value;
-                        },
-                        decoration: InputDecoration(
-                          border: OutlineInputBorder(
-                              borderRadius: BorderRadius.circular(0.1)),
-                        ),
-                        style: TextStyle(
-                          fontFamily: 'Roboto',
-                          fontSize: 12,
-                          color: const Color(0xff1A2677),
-                          letterSpacing: 0.1875,
-                          fontWeight: FontWeight.w500,
-                          height: 1.2,
-                        ),
-                        textAlign: TextAlign.center,
-                      ),
+                      height: 30,
+                      child: widget.city.trimRight().isEmpty
+                          ? TextField(
+                              controller: cityController,
+                              decoration: InputDecoration(
+                                hintText: 'Write your city here',
+                                contentPadding:
+                                    EdgeInsets.fromLTRB(20.0, 15.0, 20.0, 0.0),
+                                prefixIcon: Icon(
+                                  FontAwesomeIcons.pencilAlt,
+                                  size: 15.0,
+                                  color: const Color(0xff1A2677),
+                                ),
+                                border: OutlineInputBorder(
+                                    borderRadius: BorderRadius.circular(10)),
+                              ),
+                              style: TextStyle(
+                                fontFamily: 'Roboto',
+                                fontSize: 12,
+                                color: const Color(0xff1A2677),
+                                letterSpacing: 0.1875,
+                                fontWeight: FontWeight.w500,
+                                height: 1.2,
+                              ),
+                              textAlign: TextAlign.center,
+                            )
+                          : TextField(
+                              controller: cityController,
+                              decoration: InputDecoration(
+                                prefixIcon: Icon(
+                                  FontAwesomeIcons.pencilAlt,
+                                  size: 15.0,
+                                  color: const Color(0xff1A2677),
+                                ),
+                                border: OutlineInputBorder(
+                                    borderRadius: BorderRadius.circular(10)),
+                              ),
+                              style: TextStyle(
+                                fontFamily: 'Roboto',
+                                fontSize: 12,
+                                color: const Color(0xff1A2677),
+                                letterSpacing: 0.1875,
+                                fontWeight: FontWeight.w500,
+                                height: 1.2,
+                              ),
+                              textAlign: TextAlign.center,
+                            ),
                     )),
               ),
               Transform.translate(
                   offset: Offset(SizeConfig.screenWidth * 70,
-                      SizeConfig.screenHeight * 390),
+                      SizeConfig.screenHeight * 400),
                   child: Container(
                     width: 250,
-                    child: TextField(
-                      controller: bioController,
-                      onChanged: (String value) async {
-                        this.bio = value;
-                      },
-                      decoration: InputDecoration(
-                          border: OutlineInputBorder(
-                              borderRadius: BorderRadius.zero)),
-                      style: TextStyle(fontWeight: FontWeight.bold),
-                      textAlign: TextAlign.left,
-                    ),
+                    child: widget.bio.trimRight().isEmpty
+                        ? TextField(
+                            controller: bioController,
+                            decoration: InputDecoration(
+                                hintText: 'Write your bio here',
+                                contentPadding:
+                                    EdgeInsets.fromLTRB(20.0, 15.0, 20.0, 0.0),
+                                prefixIcon: Icon(
+                                  FontAwesomeIcons.pencilAlt,
+                                  size: 15.0,
+                                  color: const Color(0xff1A2677),
+                                ),
+                                border: OutlineInputBorder(
+                                    borderRadius: BorderRadius.circular(10))),
+                            style: TextStyle(
+                              fontWeight: FontWeight.bold,
+                              color: const Color(0xff1A2677),
+                            ),
+                            textAlign: TextAlign.left,
+                          )
+                        : TextField(
+                            controller: bioController,
+                            decoration: InputDecoration(
+                                contentPadding:
+                                    EdgeInsets.fromLTRB(20.0, 15.0, 20.0, 0.0),
+                                prefixIcon: Icon(
+                                  FontAwesomeIcons.pencilAlt,
+                                  size: 15.0,
+                                  color: const Color(0xff1A2677),
+                                ),
+                                border: OutlineInputBorder(
+                                    borderRadius: BorderRadius.circular(10))),
+                            style: TextStyle(
+                              fontWeight: FontWeight.bold,
+                              color: const Color(0xff1A2677),
+                            ),
+                            textAlign: TextAlign.left,
+                          ),
+                  )),
+              Transform.translate(
+                  offset: Offset(SizeConfig.screenWidth * 70,
+                      SizeConfig.screenHeight * 600),
+                  child: Container(
+                    width: 250,
+                    child: widget.area.trimRight().isEmpty
+                        ? TextField(
+                            controller: areaController,
+                            decoration: InputDecoration(
+                                hintText: 'Write your area here',
+                                contentPadding:
+                                    EdgeInsets.fromLTRB(20.0, 15.0, 20.0, 0.0),
+                                prefixIcon: Icon(
+                                  FontAwesomeIcons.pencilAlt,
+                                  size: 15.0,
+                                  color: const Color(0xff1A2677),
+                                ),
+                                border: OutlineInputBorder(
+                                    borderRadius: BorderRadius.circular(10))),
+                            style: TextStyle(
+                              fontWeight: FontWeight.bold,
+                              color: const Color(0xff1A2677),
+                            ),
+                            textAlign: TextAlign.left,
+                          )
+                        : TextField(
+                            controller: areaController,
+                            decoration: InputDecoration(
+                                contentPadding:
+                                    EdgeInsets.fromLTRB(20.0, 15.0, 20.0, 0.0),
+                                prefixIcon: Icon(
+                                  FontAwesomeIcons.pencilAlt,
+                                  size: 15.0,
+                                  color: const Color(0xff1A2677),
+                                ),
+                                border: OutlineInputBorder(
+                                    borderRadius: BorderRadius.circular(10))),
+                            style: TextStyle(
+                              fontWeight: FontWeight.bold,
+                              color: const Color(0xff1A2677),
+                            ),
+                            textAlign: TextAlign.left,
+                          ),
                   )),
               Transform.translate(
                 offset: Offset(SizeConfig.screenWidth * 59.5,
                     SizeConfig.screenHeight * 365),
                 child: Text(
-                  'Bio',
+                  'Biography',
                   style: TextStyle(
                     fontFamily: 'Roboto',
                     fontSize: 20,
@@ -429,20 +539,45 @@ class _EditProfile1 extends State<EditProfile1> {
               ),
               Transform.translate(
                   offset: Offset(SizeConfig.screenWidth * 70,
-                      SizeConfig.screenHeight * 495),
+                      SizeConfig.screenHeight * 500),
                   child: Container(
                     width: 250,
-                    child: TextField(
-                      controller: jobController,
-                      onChanged: (String value) async {
-                        job = value;
-                      },
-                      decoration: InputDecoration(
-                          border: OutlineInputBorder(
-                              borderRadius: BorderRadius.zero)),
-                      style: TextStyle(fontWeight: FontWeight.bold),
-                      textAlign: TextAlign.left,
-                    ),
+                    child: widget.job.trimRight().isEmpty
+                        ? TextField(
+                            controller: jobController,
+                            decoration: InputDecoration(
+                                hintText: 'Write your job here',
+                                contentPadding:
+                                    EdgeInsets.fromLTRB(20.0, 15.0, 20.0, 0.0),
+                                prefixIcon: Icon(
+                                  FontAwesomeIcons.pencilAlt,
+                                  size: 15.0,
+                                  color: const Color(0xff1A2677),
+                                ),
+                                border: OutlineInputBorder(
+                                    borderRadius: BorderRadius.circular(10))),
+                            style: TextStyle(
+                                fontWeight: FontWeight.bold,
+                                color: const Color(0xff1A2677)),
+                            textAlign: TextAlign.left,
+                          )
+                        : TextField(
+                            controller: jobController,
+                            decoration: InputDecoration(
+                                contentPadding:
+                                    EdgeInsets.fromLTRB(20.0, 15.0, 20.0, 0.0),
+                                prefixIcon: Icon(
+                                  FontAwesomeIcons.pencilAlt,
+                                  size: 15.0,
+                                  color: const Color(0xff1A2677),
+                                ),
+                                border: OutlineInputBorder(
+                                    borderRadius: BorderRadius.circular(10))),
+                            style: TextStyle(
+                                fontWeight: FontWeight.bold,
+                                color: const Color(0xff1A2677)),
+                            textAlign: TextAlign.left,
+                          ),
                   )),
               Transform.translate(
                 offset: Offset(SizeConfig.screenWidth * 59.5,
@@ -461,58 +596,45 @@ class _EditProfile1 extends State<EditProfile1> {
                 ),
               ),
               Transform.translate(
-                  offset: Offset(SizeConfig.screenWidth * 70,
-                      SizeConfig.screenHeight * 595),
-                  child: Container(
-                    width: 250,
-                    child: TextField(
-                      controller: areaController,
-                      onChanged: (String value) async {
-                        area = value;
-                      },
-                      decoration: InputDecoration(
-                          border: OutlineInputBorder(
-                              borderRadius: BorderRadius.zero)),
-                      style: TextStyle(fontWeight: FontWeight.bold),
-                      textAlign: TextAlign.left,
-                    ),
-                  )),
-              Transform.translate(
                 offset: Offset(SizeConfig.screenWidth * 59.5,
                     SizeConfig.screenHeight * 570),
                 child: Text(
                   'Area',
                   style: TextStyle(
-                    fontFamily: 'Roboto',
-                    fontSize: 20,
-                    color: const Color(0xff1A2677),
-                    letterSpacing: 0.36,
-                    fontWeight: FontWeight.w500,
-                    height: 1
-                  ),
+                      fontFamily: 'Roboto',
+                      fontSize: 20,
+                      color: const Color(0xff1A2677),
+                      letterSpacing: 0.36,
+                      fontWeight: FontWeight.w500,
+                      height: 1),
                   textAlign: TextAlign.left,
                 ),
               ),
               Transform.translate(
                 offset: Offset(SizeConfig.screenWidth * 80,
-                    SizeConfig.screenHeight * 230.0),
+                    SizeConfig.screenHeight * 240.0),
                 child: SizedBox(
                   width: 226.0,
+                  height: 50.0,
                   child: TextField(
                     controller: nameController,
-                    onChanged: (String value) async {
-                      name = value;
-                    },
                     decoration: InputDecoration(
+                        contentPadding:
+                            EdgeInsets.fromLTRB(20.0, 0.0, 0.0, 0.0),
+                        prefixIcon: Icon(
+                          FontAwesomeIcons.pencilAlt,
+                          size: 15.0,
+                          color: const Color(0xff1A2677),
+                        ),
                         border: OutlineInputBorder(
-                            borderRadius: BorderRadius.zero)),
+                            borderRadius: BorderRadius.circular(10))),
                     style: TextStyle(
                       fontFamily: 'Roboto',
                       fontSize: 30,
                       color: const Color(0xff1A2677),
-                      letterSpacing: 0.28125,
+                      letterSpacing: 0.1875,
                       fontWeight: FontWeight.w500,
-                      height: 0.8,
+                      height: 1.5,
                     ),
                     textAlign: TextAlign.center,
                   ),
@@ -527,30 +649,13 @@ class _EditProfile1 extends State<EditProfile1> {
                         child: Stack(children: <Widget>[
                   CircleAvatar(
                     backgroundImage: _imageFile == null
-                        ? NetworkImage(this.image)
+                        ? NetworkImage(widget.image)
                         : FileImage(File(_imageFile.path)),
                     radius: 50,
                   ),
                   Positioned(
-                    bottom: 35.0,
-                    right: 55.0,
-                    child: InkWell(
-                      onTap: () {
-                        showModalBottomSheet(
-                          context: context,
-                          builder: ((builder) => bottomSheet()),
-                        );
-                      },
-                      child: Icon(
-                        FontAwesomeIcons.retweet,
-                        color: const Color(0xffffffff),
-                        size: 30.0,
-                      ),
-                    ),
-                  ),
-                  Positioned(
-                    bottom: 35.0,
-                    right: 15.0,
+                    bottom: 0.0,
+                    right: 0.0,
                     child: InkWell(
                       onTap: () {
                         showModalBottomSheet(
@@ -560,7 +665,7 @@ class _EditProfile1 extends State<EditProfile1> {
                       },
                       child: Icon(
                         FontAwesomeIcons.camera,
-                        color: const Color(0xffffffff),
+                        color: const Color(0xff1A2677),
                         size: 30.0,
                       ),
                     ),
@@ -578,11 +683,11 @@ class _EditProfile1 extends State<EditProfile1> {
                         child: InkWell(
                           splashColor: const Color(0xff1A2677), // splash color
                           onTap: () async {
-                            if ((name != nameController.value.text) ||
-                                (city != cityController.value.text) ||
-                                (area != areaController.value.text) ||
-                                (job != jobController.value.text) ||
-                                (bio != bioController.value.text)) {
+                            if ((widget.name != nameController.value.text) ||
+                                (widget.city != cityController.value.text) ||
+                                (widget.area != areaController.value.text) ||
+                                (widget.job != jobController.value.text) ||
+                                (widget.bio != bioController.value.text)) {
                               check(context);
                             } else {
                               FirebaseDatabase.instance
@@ -594,13 +699,13 @@ class _EditProfile1 extends State<EditProfile1> {
                                     MaterialPageRoute(
                                         builder: (context) => MyProfile1(
                                             auth: auth,
-                                            image: image,
-                                            name: name,
-                                            job: job,
+                                            image: widget.image,
+                                            name: widget.name,
+                                            job: widget.job,
                                             interests: interests,
-                                            city: city,
-                                            bio: bio,
-                                            area: area,
+                                            city: widget.city,
+                                            bio: widget.bio,
+                                            area: widget.area,
                                             linkedin: linkedin,
                                             facebook: facebook,
                                             instagram: instagram,

--- a/conferecebook/lib/EnterEventCode.dart
+++ b/conferecebook/lib/EnterEventCode.dart
@@ -26,9 +26,10 @@ class SizeConfig {
 }
 
 class EnterEventCode extends StatefulWidget {
-  EnterEventCode({Key key, this.auth}) : super(key: key);
+  EnterEventCode({Key key, this.auth, this.previous}) : super(key: key);
 
   final FirebaseAuth auth;
+  final String previous;
 
   @override
   State<StatefulWidget> createState() => _EnterEventCode();
@@ -159,6 +160,8 @@ class _EnterEventCode extends State<EnterEventCode> {
   bool _success = false;
   FirebaseAuth auth;
 
+  String previous;
+
   Future<String> _register() async {
     await FirebaseDatabase.instance
         .reference()
@@ -203,6 +206,7 @@ class _EnterEventCode extends State<EnterEventCode> {
   @override
   Widget build(BuildContext context) {
     auth = widget.auth;
+    previous = widget.previous;
     SizeConfig().init(context);
     return WillPopScope(
         onWillPop: () async => false,
@@ -222,18 +226,33 @@ class _EnterEventCode extends State<EnterEventCode> {
                             padding: EdgeInsets.only(top: 25.0, left: 10.0),
                             child: FloatingActionButton(
                               onPressed: () async {
-                                FirebaseDatabase.instance
-                                    .reference()
-                                    .once()
-                                    .then((DataSnapshot snapshot) {
-                                  Map<dynamic, dynamic> map = snapshot.value;
-                                  Navigator.of(context)
-                                      .pushReplacement(MaterialPageRoute(
-                                          builder: (context) => JoinAnEvent(
-                                                auth: widget.auth,
-                                                map: map,
-                                              )));
-                                });
+                                if (previous != "") {
+                                  FirebaseDatabase.instance
+                                      .reference()
+                                      .once()
+                                      .then((DataSnapshot snapshot) {
+                                    Map<dynamic, dynamic> map = snapshot.value;
+                                    Navigator.of(context).pushReplacement(MaterialPageRoute(
+                                        builder: (context) => HomeFeed(
+                                          auth: this.auth,
+                                          code: previous,
+                                          map: map,
+                                        )));
+                                  });
+                                } else {
+                                  FirebaseDatabase.instance
+                                      .reference()
+                                      .once()
+                                      .then((DataSnapshot snapshot) {
+                                    Map<dynamic, dynamic> map = snapshot.value;
+                                    Navigator.of(context)
+                                        .pushReplacement(MaterialPageRoute(
+                                            builder: (context) => JoinAnEvent(
+                                                  auth: widget.auth,
+                                                  map: map,
+                                                )));
+                                  });
+                                }
                               },
                               backgroundColor: const Color(0xff1A2677),
                               child: Icon(

--- a/conferecebook/lib/JoinAnEvent.dart
+++ b/conferecebook/lib/JoinAnEvent.dart
@@ -193,6 +193,7 @@ class _JoinAnEvent extends State<JoinAnEvent> {
                                   duration: 0.3,
                                   pageBuilder: () => EnterEventCode(
                                     auth: auth,
+                                    previous: "",
                                   ),
                                 ),
                               ],
@@ -429,6 +430,7 @@ class _JoinAnEvent extends State<JoinAnEvent> {
                                   duration: 0.3,
                                   pageBuilder: () => EnterEventCode(
                                     auth: auth,
+                                    previous: "",
                                   ),
                                 ),
                               ],

--- a/conferecebook/lib/Login.dart
+++ b/conferecebook/lib/Login.dart
@@ -1,4 +1,5 @@
 import 'package:ConfereceBook/JoinAnEvent.dart';
+import 'package:ConfereceBook/ResetPassword.dart';
 import 'package:firebase_database/firebase_database.dart';
 import 'package:flutter/material.dart';
 import 'package:adobe_xd/pinned.dart';
@@ -237,6 +238,51 @@ class _MyLogin extends State<MyLogin> {
                   ],
                   child: Text(
                     'Create account!',
+                    style: TextStyle(
+                      fontFamily: 'Roboto',
+                      fontSize: 16,
+                      color: const Color(0xff1A2677),
+                      letterSpacing: 0.15,
+                      decoration: TextDecoration.underline,
+                      height: 1.5,
+                    ),
+                    textAlign: TextAlign.left,
+                  ),
+                ),
+              ),
+              Transform.translate(
+                offset: Offset(SizeConfig.screenWidth * 53.5,
+                    SizeConfig.screenHeight * 680.0),
+                child:
+                // Adobe XD layer: '✏️ Input text' (text)
+                Text(
+                  'Forgot your password?',
+                  style: TextStyle(
+                    fontFamily: 'Roboto',
+                    fontSize: 16,
+                    color: const Color(0x99000000),
+                    letterSpacing: 0.15,
+                    height: 1.5,
+                  ),
+                  textAlign: TextAlign.left,
+                ),
+              ),
+              Transform.translate(
+                offset: Offset(SizeConfig.screenWidth * 53.5,
+                    SizeConfig.screenHeight * 703.0),
+                child:
+                // Adobe XD layer: '✏️ Input text' (text)
+                PageLink(
+                  links: [
+                    PageLinkInfo(
+                      transition: LinkTransition.Fade,
+                      ease: Curves.easeOut,
+                      duration: 0.3,
+                      pageBuilder: () => MyResetPassword(auth: auth),
+                    ),
+                  ],
+                  child: Text(
+                    'Reset Password',
                     style: TextStyle(
                       fontFamily: 'Roboto',
                       fontSize: 16,

--- a/conferecebook/lib/ModerationSettings.dart
+++ b/conferecebook/lib/ModerationSettings.dart
@@ -104,7 +104,7 @@ class _ModerationSettings extends State<ModerationSettings> {
                   //initial value
                   value: postsFromSponsors,
                   textOn: 'Allowed',
-                  textOff: 'No',
+                  textOff: 'Blocked',
                   colorOn: Color(0xff1A2677),
                   colorOff: Colors.black54,
                   iconOn: Icons.done,
@@ -129,7 +129,7 @@ class _ModerationSettings extends State<ModerationSettings> {
                   //initial value
                   value: postsFromSpeakers,
                   textOn: 'Allowed',
-                  textOff: 'No',
+                  textOff: 'Blocked',
                   colorOn: Color(0xff1A2677),
                   colorOff: Colors.black54,
                   iconOn: Icons.done,
@@ -154,7 +154,7 @@ class _ModerationSettings extends State<ModerationSettings> {
                   //initial value
                   value: postsFromAttendees,
                   textOn: 'Allowed',
-                  textOff: 'No',
+                  textOff: 'Blocked',
                   colorOn: Color(0xff1A2677),
                   colorOff: Colors.black54,
                   iconOn: Icons.done,

--- a/conferecebook/lib/MyProfile1.dart
+++ b/conferecebook/lib/MyProfile1.dart
@@ -117,7 +117,11 @@ class _MyProfile1 extends State<MyProfile1> {
     code = widget.code;
 
     return WillPopScope(
-        onWillPop: () async => false,
+        // ignore: missing_return
+        onWillPop: () {
+          Navigator.pop(context);
+          Navigator.pop(context);
+        },
         child: Scaffold(
           backgroundColor: const Color(0xffffffff),
           body: Stack(
@@ -153,11 +157,15 @@ class _MyProfile1 extends State<MyProfile1> {
                 child: SizedBox(
                   width: SizeConfig.screenWidth * 100.0,
                   child: Text(
-                    this.city,
+                    this.city.trimRight().isEmpty
+                        ? 'Undefined city'
+                        : this.city,
                     style: TextStyle(
                       fontFamily: 'Roboto',
                       fontSize: 12,
-                      color: const Color(0xff1A2677),
+                      color: this.city.trimRight().isEmpty
+                          ? const Color(0xffd3d3d3)
+                          : const Color(0xff1A2677),
                       letterSpacing: 0.1875,
                       fontWeight: FontWeight.w500,
                       height: 1.2,
@@ -173,10 +181,14 @@ class _MyProfile1 extends State<MyProfile1> {
                     width: 200,
                     height: 20,
                     child: Text(
-                      bio,
+                      bio.trimRight().isEmpty ? 'Undefined bio' : bio,
                       textAlign: TextAlign.left,
                       overflow: TextOverflow.ellipsis,
-                      style: TextStyle(fontWeight: FontWeight.bold),
+                      style: TextStyle(
+                          fontWeight: FontWeight.bold,
+                          color: bio.trimRight().isEmpty
+                              ? const Color(0xffd3d3d3)
+                              : const Color(0xff1A2677)),
                     )),
               ),
               Transform.translate(
@@ -225,10 +237,14 @@ class _MyProfile1 extends State<MyProfile1> {
                     width: 200,
                     height: 20,
                     child: Text(
-                      job,
+                      job.trimRight().isEmpty ? 'Undefined job' : job,
                       textAlign: TextAlign.left,
                       overflow: TextOverflow.ellipsis,
-                      style: TextStyle(fontWeight: FontWeight.bold),
+                      style: TextStyle(
+                          fontWeight: FontWeight.bold,
+                          color: job.trimRight().isEmpty
+                              ? const Color(0xffd3d3d3)
+                              : const Color(0xff1A2677)),
                     )),
               ),
               Transform.translate(
@@ -276,10 +292,14 @@ class _MyProfile1 extends State<MyProfile1> {
                     width: 200,
                     height: 20,
                     child: Text(
-                      area,
+                      area.trimRight().isEmpty ? 'Undefined area' : area,
                       textAlign: TextAlign.left,
                       overflow: TextOverflow.ellipsis,
-                      style: TextStyle(fontWeight: FontWeight.bold),
+                      style: TextStyle(
+                          fontWeight: FontWeight.bold,
+                          color: area.trimRight().isEmpty
+                              ? const Color(0xffd3d3d3)
+                              : const Color(0xff1A2677)),
                     )),
               ),
               Transform.translate(
@@ -350,7 +370,7 @@ class _MyProfile1 extends State<MyProfile1> {
                           padding: EdgeInsets.only(bottom: 75.0, right: 35.0),
                           child: FloatingActionButton(
                             onPressed: () async {
-                              Navigator.of(context).pushReplacement(
+                              Navigator.push(context,
                                   MaterialPageRoute(
                                       builder: (context) => MyProfile2(
                                           auth: auth,
@@ -381,7 +401,27 @@ class _MyProfile1 extends State<MyProfile1> {
                   )
                 ],
               )),
-              Container(),
+              Transform.translate(
+                  offset: Offset(SizeConfig.screenWidth * 10,
+                      SizeConfig.screenHeight * 20 + 20),
+                  child: SizedBox.fromSize(
+                    size: Size(56, 56), // button width and height
+                    child: ClipOval(
+                      child: Material(
+                        color: const Color(0xff1A2677), // button color
+                        child: InkWell(
+                          splashColor: const Color(0xff1A2677), // splash color
+                          onTap: () async {
+                            Navigator.of(context).pop();
+                          }, // button pressed
+                          child: Icon(
+                            FontAwesomeIcons.arrowLeft,
+                            color: Colors.white,
+                          ), // icon
+                        ),
+                      ),
+                    ),
+                  )),
               Transform.translate(
                 offset: Offset(SizeConfig.screenWidth * 150,
                     SizeConfig.screenHeight * 100.0),
@@ -496,38 +536,7 @@ class _MyProfile1 extends State<MyProfile1> {
                       ),
                     ),
                   )),
-              Transform.translate(
-                  offset: Offset(SizeConfig.screenWidth * 10,
-                      SizeConfig.screenHeight * 20 + 20),
-                  child: SizedBox.fromSize(
-                    size: Size(56, 56), // button width and height
-                    child: ClipOval(
-                      child: Material(
-                        color: const Color(0xff1A2677), // button color
-                        child: InkWell(
-                          splashColor: const Color(0xff1A2677), // splash color
-                          onTap: () async {
-                            FirebaseDatabase.instance
-                                .reference()
-                                .once()
-                                .then((DataSnapshot snapshot) {
-                              Map<dynamic, dynamic> map = snapshot.value;
-                              Navigator.of(context).pushReplacement(
-                                  MaterialPageRoute(
-                                      builder: (context) => HomeFeed(
-                                          auth: widget.auth,
-                                          code: widget.code,
-                                          map: map)));
-                            });
-                          }, // button pressed
-                          child: Icon(
-                            FontAwesomeIcons.home,
-                            color: Colors.white,
-                          ), // icon
-                        ),
-                      ),
-                    ),
-                  )),
+
             ],
           ),
         ));

--- a/conferecebook/lib/MyProfile2.dart
+++ b/conferecebook/lib/MyProfile2.dart
@@ -129,15 +129,20 @@ class _MyProfile2 extends State<MyProfile2> {
     city = widget.city;
     bio = widget.bio;
     area = widget.area;
-    facebook = widget.facebook;
-    instagram = widget.instagram;
-    linkedin = widget.linkedin;
-    twitter = widget.twitter;
-    github = widget.github;
+    facebook = widget.facebook == null ? "" : widget.facebook;
+    instagram = widget.instagram == null ? "" : widget.instagram;
+    linkedin = widget.linkedin == null ? "" : widget.linkedin;
+    twitter = widget.twitter == null ? "" : widget.twitter;
+    github = widget.github == null? "" : widget.github;
+
     myInterests = interests.split(',').toList();
 
     return WillPopScope(
-        onWillPop: () async => false,
+        // ignore: missing_return
+        onWillPop: () {
+          Navigator.pop(context);
+          Navigator.pop(context);
+        },
         child: Scaffold(
           backgroundColor: const Color(0xffffffff),
           body: Stack(
@@ -213,11 +218,15 @@ class _MyProfile2 extends State<MyProfile2> {
                 child: SizedBox(
                   width: SizeConfig.screenWidth * 100.0,
                   child: Text(
-                    this.city,
+                    this.city.trimRight().isEmpty
+                        ? 'Undefined city'
+                        : this.city,
                     style: TextStyle(
                       fontFamily: 'Roboto',
                       fontSize: 12,
-                      color: const Color(0xff1A2677),
+                      color: this.city.trimRight().isEmpty
+                          ? const Color(0xffd3d3d3)
+                          : const Color(0xff1A2677),
                       letterSpacing: 0.1875,
                       fontWeight: FontWeight.w500,
                       height: 1.2,
@@ -226,20 +235,8 @@ class _MyProfile2 extends State<MyProfile2> {
                   ),
                 ),
               ),
-              Container(),
-              Container(),
-              Container(),
-              Container(),
-              Container(),
-              Container(),
-              Container(),
-              Container(),
-              Container(),
-              Container(),
-              Container(),
-              Container(),
               Transform.translate(
-                offset: Offset(SizeConfig.screenWidth * 130,
+                offset: Offset(SizeConfig.screenWidth * 140,
                     SizeConfig.screenHeight * 350),
                 child: Text(
                   'Social Media',
@@ -255,7 +252,7 @@ class _MyProfile2 extends State<MyProfile2> {
                 ),
               ),
               Transform.translate(
-                offset: Offset(SizeConfig.screenWidth * 150,
+                offset: Offset(SizeConfig.screenWidth * 158,
                     SizeConfig.screenHeight * 550),
                 child: Text(
                   'Interests',
@@ -275,36 +272,49 @@ class _MyProfile2 extends State<MyProfile2> {
                       SizeConfig.screenHeight * 600),
                   child: Container(
                     width: SizeConfig.screenWidth * 250,
-                    child: Tags(
-                      key: _tagStateKey,
-                      itemCount: myInterests.length, // required
-                      itemBuilder: (int index) {
-                        final item = myInterests[index];
-                        return ItemTags(
-                          // Each ItemTags must contain a Key. Keys allow Flutter to
-                          // uniquely identify widgets.
-                          key: Key(index.toString()),
-                          index: index,
-                          // required
-                          title: item,
-                          textStyle: TextStyle(
-                            fontSize: 10,
+                    child: interests.trimRight().isEmpty
+                        ? Text(
+                            'No interest',
+                            style: TextStyle(
+                              fontFamily: 'Roboto',
+                              fontSize: 15,
+                              color: const Color(0xffd3d3d3),
+                              letterSpacing: 0.36,
+                              fontWeight: FontWeight.w500,
+                              height: 1,
+                            ),
+                            textAlign: TextAlign.center,
+                          )
+                        : Tags(
+                            key: _tagStateKey,
+                            itemCount: myInterests.length, // required
+                            itemBuilder: (int index) {
+                              final item = myInterests[index];
+                              return ItemTags(
+                                // Each ItemTags must contain a Key. Keys allow Flutter to
+                                // uniquely identify widgets.
+                                key: Key(index.toString()),
+                                index: index,
+                                // required
+                                title: item,
+                                textStyle: TextStyle(
+                                  fontSize: 10,
+                                ),
+                                combine: ItemTagsCombine.withTextBefore,
+                                image: null,
+                                // OR null,
+                                icon: null,
+                                // OR null,
+                                removeButton: null,
+                                // OR null,
+                                onPressed: (item) => print(item),
+                                onLongPressed: (item) => print(item),
+                              );
+                            },
                           ),
-                          combine: ItemTagsCombine.withTextBefore,
-                          image: null,
-                          // OR null,
-                          icon: null,
-                          // OR null,
-                          removeButton: null,
-                          // OR null,
-                          onPressed: (item) => print(item),
-                          onLongPressed: (item) => print(item),
-                        );
-                      },
-                    ),
                   )),
               Transform.translate(
-                offset: Offset(SizeConfig.screenWidth * 200,
+                offset: Offset(SizeConfig.screenWidth * 210,
                     SizeConfig.screenHeight * 440.0),
                 child: Container(
                     child: IconButton(
@@ -327,7 +337,7 @@ class _MyProfile2 extends State<MyProfile2> {
                         })),
               ),
               Transform.translate(
-                offset: Offset(SizeConfig.screenWidth * 220,
+                offset: Offset(SizeConfig.screenWidth * 230,
                     SizeConfig.screenHeight * 380.0),
                 child: Container(
                     child: IconButton(
@@ -349,7 +359,7 @@ class _MyProfile2 extends State<MyProfile2> {
                         })),
               ),
               Transform.translate(
-                offset: Offset(SizeConfig.screenWidth * 150,
+                offset: Offset(SizeConfig.screenWidth * 160,
                     SizeConfig.screenHeight * 440.0),
                 child: Container(
                     child: IconButton(
@@ -371,7 +381,7 @@ class _MyProfile2 extends State<MyProfile2> {
                         })),
               ),
               Transform.translate(
-                offset: Offset(SizeConfig.screenWidth * 170,
+                offset: Offset(SizeConfig.screenWidth * 180,
                     SizeConfig.screenHeight * 380.0),
                 child: Container(
                     child: IconButton(
@@ -394,7 +404,7 @@ class _MyProfile2 extends State<MyProfile2> {
                         })),
               ),
               Transform.translate(
-                offset: Offset(SizeConfig.screenWidth * 120,
+                offset: Offset(SizeConfig.screenWidth * 130,
                     SizeConfig.screenHeight * 380.0),
                 child: Container(
                     child: IconButton(
@@ -482,21 +492,11 @@ class _MyProfile2 extends State<MyProfile2> {
                         child: InkWell(
                           splashColor: const Color(0xff1A2677), // splash color
                           onTap: () async {
-                            FirebaseDatabase.instance
-                                .reference()
-                                .once()
-                                .then((DataSnapshot snapshot) {
-                              Map<dynamic, dynamic> map = snapshot.value;
-                              Navigator.of(context).pushReplacement(
-                                  MaterialPageRoute(
-                                      builder: (context) => HomeFeed(
-                                          auth: widget.auth,
-                                          code: widget.code,
-                                          map: map)));
-                            });
+                            Navigator.of(context).pop();
+                            Navigator.of(context).pop();
                           }, // button pressed
                           child: Icon(
-                            FontAwesomeIcons.home,
+                            FontAwesomeIcons.arrowLeft,
                             color: Colors.white,
                           ), // icon
                         ),

--- a/conferecebook/lib/ParticipantsList.dart
+++ b/conferecebook/lib/ParticipantsList.dart
@@ -97,7 +97,7 @@ class _ParticipantsList extends State<ParticipantsList> {
                     onPressed: () async {
                       this.searchToDo = _textFieldController.text;
                       Navigator.of(context).pop();
-                      Navigator.of(context).pushReplacement(MaterialPageRoute(
+                      Navigator.push(context, MaterialPageRoute(
                           builder: (context) => SearchParticipants(
                               auth: auth,
                               code: widget.code,
@@ -406,8 +406,42 @@ class _ParticipantsList extends State<ParticipantsList> {
                               icon: Icon(FontAwesomeIcons.arrowRight,
                                   color: Color(0xff1A2677)),
                               onPressed: () async {
-                                Navigator.of(context)
-                                    .pushReplacement(MaterialPageRoute(
+                                if (auth.currentUser.uid == userToSee) {
+                                  String user = auth.currentUser.uid;
+                                  String image = map.values.toList()[2][user]["photo"];
+                                  String name = map.values.toList()[2][user]["name"];
+                                  String job = map.values.toList()[2][user]["job"];
+                                  String interests =
+                                  map.values.toList()[2][user]["interests"];
+                                  String city = map.values.toList()[2][user]["city"];
+                                  String bio = map.values.toList()[2][user]["bio"];
+                                  String area = map.values.toList()[2][user]["area"];
+                                  String linkedin =
+                                  map.values.toList()[2][user]["linkedin"];
+                                  String facebook =
+                                  map.values.toList()[2][user]["facebook"];
+                                  String instagram =
+                                  map.values.toList()[2][user]["instagram"];
+                                  String twitter = map.values.toList()[2][user]["twitter"];
+                                  String github = map.values.toList()[2][user]["github"];
+                                  Navigator.push(context, MaterialPageRoute(
+                                      builder: (context) => MyProfile1(
+                                          auth: auth,
+                                          image: image,
+                                          name: name,
+                                          job: job,
+                                          interests: interests,
+                                          city: city,
+                                          bio: bio,
+                                          area: area,
+                                          linkedin: linkedin,
+                                          facebook: facebook,
+                                          instagram: instagram,
+                                          twitter: twitter,
+                                          github: github,
+                                          code: code)));
+                                } else {
+                                Navigator.push(context, MaterialPageRoute(
                                         builder: (context) => ViewProfile1(
                                               auth: auth,
                                               userToSee: userToSee,
@@ -415,6 +449,7 @@ class _ParticipantsList extends State<ParticipantsList> {
                                               map: map,
                                               code: widget.code,
                                             )));
+                                }
                               })),
                       semanticContainer: true,
                       clipBehavior: Clip.antiAliasWithSaveLayer,

--- a/conferecebook/lib/ResetPassword.dart
+++ b/conferecebook/lib/ResetPassword.dart
@@ -1,0 +1,221 @@
+import 'package:ConfereceBook/JoinAnEvent.dart';
+import 'package:ConfereceBook/Login.dart';
+import 'package:firebase_database/firebase_database.dart';
+import 'package:flutter/material.dart';
+import 'package:adobe_xd/pinned.dart';
+import './CreateProfile1.dart';
+import 'package:adobe_xd/page_link.dart';
+import 'package:flutter/widgets.dart';
+
+// Import the firebase_core plugin
+import 'package:firebase_core/firebase_core.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+
+class SizeConfig {
+  static MediaQueryData _mediaQueryData;
+  static double screenWidth;
+  static double screenHeight;
+  static double blockSizeHorizontal;
+  static double blockSizeVertical;
+
+  void init(BuildContext context) {
+    _mediaQueryData = MediaQuery.of(context);
+    screenWidth = _mediaQueryData.size.width / 412;
+    screenHeight = _mediaQueryData.size.height / 870;
+  }
+}
+
+class MyResetPassword extends StatefulWidget {
+  MyResetPassword({Key key, this.auth}) : super(key: key);
+
+  final FirebaseAuth auth;
+
+  @override
+  _MyResetPassword createState() => _MyResetPassword();
+}
+
+class _MyResetPassword extends State<MyResetPassword> {
+  FirebaseAuth auth;
+  String email;
+  String password;
+
+  sendPasswordResetEmail(String email) async {
+    try {
+      await auth.sendPasswordResetEmail(email: email).then((value) {
+        showAlertDialog2(context);
+      });
+    } catch (e) {
+      showAlertDialog(context);
+    }
+  }
+
+  showAlertDialog(BuildContext context) {
+    // configura o button
+    Widget okButton = FlatButton(
+      child: Text("OK"),
+      onPressed: () {
+        Navigator.of(context).pop();
+      },
+    );
+    // configura o  AlertDialog
+    AlertDialog alerta = AlertDialog(
+      title: Text("Invalid Email"),
+      content:
+          Text("The e-mail you entered is not associated with any account."),
+      actions: [
+        okButton,
+      ],
+    );
+    // exibe o dialog
+    showDialog(
+      context: context,
+      builder: (BuildContext context) {
+        return alerta;
+      },
+    );
+  }
+
+  showAlertDialog2(BuildContext context) {
+    // configura o button
+    Widget okButton = FlatButton(
+      child: Text("OK"),
+      onPressed: () {
+        Navigator.of(context).pushReplacement(MaterialPageRoute(
+            builder: (context) => MyLogin(
+                  auth: auth,
+                )));
+      },
+    );
+    // configura o  AlertDialog
+    AlertDialog alerta = AlertDialog(
+      title: Text("Check your e-mail"),
+      content:
+          Text("You will receive shortly an e-mail to reset your password"),
+      actions: [
+        okButton,
+      ],
+    );
+    // exibe o dialog
+    showDialog(
+      context: context,
+      builder: (BuildContext context) {
+        return alerta;
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    auth = widget.auth;
+    SizeConfig().init(context);
+    return Scaffold(
+      backgroundColor: const Color(0xffffffff),
+      body: Stack(
+        children: <Widget>[
+          Container(),
+          Container(),
+          Transform.translate(
+            offset: Offset(
+                SizeConfig.screenWidth * 53.5, SizeConfig.screenHeight * 350.0),
+            child: Container(
+              width: 270.0,
+              child: TextField(
+                onChanged: (String value) async {
+                  this.email = value.trim();
+                },
+                obscureText: false,
+                decoration: InputDecoration(
+                  icon: Icon(Icons.person, color: const Color(0xff1A2677)),
+                  hintText: 'E-mail',
+                  border: InputBorder.none,
+                ),
+                style: TextStyle(
+                  fontFamily: 'Roboto',
+                  fontSize: 16,
+                  color: const Color(0xff1A2677),
+                  letterSpacing: 0.15,
+                  height: 1,
+                ),
+                textAlign: TextAlign.left,
+              ),
+            ),
+          ),
+          Transform.translate(
+            offset: Offset(SizeConfig.screenWidth * 132.0,
+                SizeConfig.screenHeight * 504.0),
+            child: SizedBox(
+              width: 149.0,
+              height: 57.0,
+              child: Stack(
+                children: <Widget>[
+                  Pinned.fromSize(
+                    bounds: Rect.fromLTWH(0.0, 0.0, 149.0, 57.0),
+                    size: Size(149.0, 57.0),
+                    pinLeft: true,
+                    pinRight: true,
+                    pinTop: true,
+                    pinBottom: true,
+                    child: Container(
+                      decoration: BoxDecoration(
+                        borderRadius: BorderRadius.circular(35.0),
+                        color: const Color(0xff1A2677),
+                        border: Border.all(
+                            width: 1.0, color: const Color(0xff1A2677)),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          Transform.translate(
+              offset: Offset(SizeConfig.screenWidth * 133,
+                  SizeConfig.screenHeight * 520.0),
+              child: InkWell(
+                  onTap: () {
+                    sendPasswordResetEmail(email);
+                  },
+                  child: SizedBox(
+                    width: 150.0,
+                    child: Text('RESET',
+                        style: TextStyle(
+                          fontFamily: 'Roboto',
+                          fontSize: 25,
+                          color: const Color(0xffffffff),
+                          letterSpacing: 1.6909999999999998,
+                          height: 1.2,
+                        ),
+                        textAlign: TextAlign.center),
+                  ))),
+          Transform.translate(
+            offset: Offset(SizeConfig.screenWidth * 164.0,
+                SizeConfig.screenHeight * 134.0),
+            child: Image.asset(
+              'images/icon.png',
+              height: 90.0,
+              width: 90.0,
+            ),
+          ),
+          Transform.translate(
+            offset: Offset(SizeConfig.screenWidth * 135.0,
+                SizeConfig.screenHeight * 829.0),
+            child: SizedBox(
+              width: SizeConfig.screenWidth * 144.0,
+              child: Text(
+                'ConferenceBook',
+                style: TextStyle(
+                  fontFamily: 'Roboto',
+                  fontSize: 16,
+                  color: const Color(0xff1A2677),
+                  letterSpacing: 0.15,
+                  height: SizeConfig.screenHeight * 1.5,
+                ),
+                textAlign: TextAlign.center,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/conferecebook/lib/SearchParticipants.dart
+++ b/conferecebook/lib/SearchParticipants.dart
@@ -127,28 +127,16 @@ class _SearchParticipants extends State<SearchParticipants> {
     searchToDo = widget.searchToDo;
 
     return WillPopScope(
-        onWillPop: () async => false,
+        // ignore: missing_return
+        onWillPop: () {
+          Navigator.pop(context);
+        },
     child: Scaffold(
       appBar: AppBar(
         leading: IconButton(
             icon: Icon(FontAwesomeIcons.arrowLeft, color: Colors.white),
             onPressed: () async {
-              FirebaseDatabase.instance
-                  .reference()
-                  .once()
-                  .then((DataSnapshot snapshot) {
-                Map<dynamic, dynamic> map = snapshot.value;
-                Navigator.of(context).pushReplacement(MaterialPageRoute(
-                    builder: (context) => ParticipantsList(
-                          auth: auth,
-                          code: code,
-                          map: map,
-                          attendeeFilter: true,
-                          speakerFilter: true,
-                          sponsorFilter: true,
-                          organizerFilter: true,
-                        )));
-              });
+              Navigator.pop(context);
             }),
         title: RichText(
           text: TextSpan(
@@ -200,15 +188,50 @@ class _SearchParticipants extends State<SearchParticipants> {
                             icon: Icon(FontAwesomeIcons.arrowRight,
                                 color: Color(0xff1A2677)),
                             onPressed: () async {
-                              Navigator.of(context)
-                                  .pushReplacement(MaterialPageRoute(
-                                      builder: (context) => ViewProfile1(
-                                            auth: auth,
-                                            userToSee: userToSee,
-                                            // id of user pressed
-                                            map: map,
-                                            code: widget.code,
-                                          )));
+                              if (auth.currentUser.uid == userToSee) {
+                                String user = auth.currentUser.uid;
+                                String image = map.values.toList()[2][user]["photo"];
+                                String name = map.values.toList()[2][user]["name"];
+                                String job = map.values.toList()[2][user]["job"];
+                                String interests =
+                                map.values.toList()[2][user]["interests"];
+                                String city = map.values.toList()[2][user]["city"];
+                                String bio = map.values.toList()[2][user]["bio"];
+                                String area = map.values.toList()[2][user]["area"];
+                                String linkedin =
+                                map.values.toList()[2][user]["linkedin"];
+                                String facebook =
+                                map.values.toList()[2][user]["facebook"];
+                                String instagram =
+                                map.values.toList()[2][user]["instagram"];
+                                String twitter = map.values.toList()[2][user]["twitter"];
+                                String github = map.values.toList()[2][user]["github"];
+                                Navigator.push(context, MaterialPageRoute(
+                                    builder: (context) => MyProfile1(
+                                        auth: auth,
+                                        image: image,
+                                        name: name,
+                                        job: job,
+                                        interests: interests,
+                                        city: city,
+                                        bio: bio,
+                                        area: area,
+                                        linkedin: linkedin,
+                                        facebook: facebook,
+                                        instagram: instagram,
+                                        twitter: twitter,
+                                        github: github,
+                                        code: code)));
+                              } else {
+                                Navigator.push(context, MaterialPageRoute(
+                                    builder: (context) => ViewProfile1(
+                                      auth: auth,
+                                      userToSee: userToSee,
+                                      // id of user pressed
+                                      map: map,
+                                      code: widget.code,
+                                    )));
+                              }
                             })),
                     semanticContainer: true,
                     clipBehavior: Clip.antiAliasWithSaveLayer,

--- a/conferecebook/lib/ViewProfile1.dart
+++ b/conferecebook/lib/ViewProfile1.dart
@@ -77,7 +77,7 @@ class _ViewProfile1 extends State<ViewProfile1> {
                 new FlatButton(
                     child: new Text('Back'),
                     onPressed: () {
-                      Navigator.of(context).pop();
+                      Navigator.pop(context);
                     }),
               ]);
         });
@@ -98,9 +98,7 @@ class _ViewProfile1 extends State<ViewProfile1> {
     job = map.values.toList()[2][userToSee]["job"];
     area = map.values.toList()[2][userToSee]["area"];
 
-    return WillPopScope(
-        onWillPop: () async => false,
-        child: Scaffold(
+    return Scaffold(
           backgroundColor: const Color(0xffffffff),
           body: Stack(
             children: <Widget>[
@@ -135,15 +133,15 @@ class _ViewProfile1 extends State<ViewProfile1> {
                 child: SizedBox(
                   width: SizeConfig.screenWidth * 100.0,
                   child: Text(
-                    this.city,
+                    this.city.trimRight().isEmpty
+                        ? 'Undefined city'
+                        : this.city,
                     style: TextStyle(
                       fontFamily: 'Roboto',
                       fontSize: 12,
-                      color: const Color(0xff1A2677),
-                      letterSpacing: 0.1875,
-                      fontWeight: FontWeight.w500,
-                      height: 1.2,
-                    ),
+                      color: this.city.trimRight().isEmpty
+                          ? const Color(0xffd3d3d3)
+                          : const Color(0xff1A2677)),
                     textAlign: TextAlign.center,
                   ),
                 ),
@@ -155,10 +153,14 @@ class _ViewProfile1 extends State<ViewProfile1> {
                     width: 200,
                     height: 20,
                     child: Text(
-                      bio,
+                      bio.trimRight().isEmpty ? 'Undefined bio' : bio,
                       textAlign: TextAlign.left,
                       overflow: TextOverflow.ellipsis,
-                      style: TextStyle(fontWeight: FontWeight.bold),
+                      style: TextStyle(
+                          fontWeight: FontWeight.bold,
+                          color: bio.trimRight().isEmpty
+                              ? const Color(0xffd3d3d3)
+                              : const Color(0xff1A2677)),
                     )),
               ),
               Transform.translate(
@@ -207,10 +209,12 @@ class _ViewProfile1 extends State<ViewProfile1> {
                     width: 200,
                     height: 20,
                     child: Text(
-                      job,
+                      job.trimRight().isEmpty ? 'Undefined job' : job,
                       textAlign: TextAlign.left,
                       overflow: TextOverflow.ellipsis,
-                      style: TextStyle(fontWeight: FontWeight.bold),
+                      style: TextStyle(fontWeight: FontWeight.bold, color: job.trimRight().isEmpty
+                          ? const Color(0xffd3d3d3)
+                          : const Color(0xff1A2677)),
                     )),
               ),
               Transform.translate(
@@ -236,10 +240,14 @@ class _ViewProfile1 extends State<ViewProfile1> {
                     width: 200,
                     height: 20,
                     child: Text(
-                      area,
+                      area.trimRight().isEmpty ? 'Undefined area' : area,
                       textAlign: TextAlign.left,
                       overflow: TextOverflow.ellipsis,
-                      style: TextStyle(fontWeight: FontWeight.bold),
+                      style: TextStyle(
+                          fontWeight: FontWeight.bold,
+                          color: area.trimRight().isEmpty
+                              ? const Color(0xffd3d3d3)
+                              : const Color(0xff1A2677)),
                     )),
               ),
               Transform.translate(
@@ -345,8 +353,7 @@ class _ViewProfile1 extends State<ViewProfile1> {
                           child: FloatingActionButton(
                             heroTag: "btn1",
                             onPressed: () async {
-                              Navigator.of(context)
-                                  .pushReplacement(MaterialPageRoute(
+                              Navigator.push(context, MaterialPageRoute(
                                       builder: (context) => ViewProfile2(
                                             auth: auth,
                                             userToSee: userToSee,
@@ -378,58 +385,10 @@ class _ViewProfile1 extends State<ViewProfile1> {
                         child: InkWell(
                           splashColor: const Color(0xff1A2677), // splash color
                           onTap: () async {
-                            FirebaseDatabase.instance
-                                .reference()
-                                .once()
-                                .then((DataSnapshot snapshot) {
-                              Map<dynamic, dynamic> map = snapshot.value;
-                              Navigator.of(context)
-                                  .pushReplacement(MaterialPageRoute(
-                                      builder: (context) => ParticipantsList(
-                                            auth: widget.auth,
-                                            code: widget.code,
-                                            map: map,
-                                            attendeeFilter: true,
-                                            speakerFilter: true,
-                                            sponsorFilter: true,
-                                            organizerFilter: true,
-                                          )));
-                            });
+                            Navigator.of(context).pop();
                           }, // button pressed
                           child: Icon(
-                            FontAwesomeIcons.users,
-                            color: Colors.white,
-                          ), // icon
-                        ),
-                      ),
-                    ),
-                  )),
-              Transform.translate(
-                  offset: Offset(SizeConfig.screenWidth * 340,
-                      SizeConfig.screenHeight * 20 + 20),
-                  child: SizedBox.fromSize(
-                    size: Size(56, 56), // button width and height
-                    child: ClipOval(
-                      child: Material(
-                        color: const Color(0xff1A2677), // button color
-                        child: InkWell(
-                          splashColor: const Color(0xff1A2677), // splash color
-                          onTap: () async {
-                            FirebaseDatabase.instance
-                                .reference()
-                                .once()
-                                .then((DataSnapshot snapshot) {
-                              Map<dynamic, dynamic> map = snapshot.value;
-                              Navigator.of(context).pushReplacement(
-                                  MaterialPageRoute(
-                                      builder: (context) => HomeFeed(
-                                          auth: widget.auth,
-                                          code: widget.code,
-                                          map: map)));
-                            });
-                          }, // button pressed
-                          child: Icon(
-                            FontAwesomeIcons.home,
+                            FontAwesomeIcons.arrowLeft,
                             color: Colors.white,
                           ), // icon
                         ),
@@ -466,6 +425,6 @@ class _ViewProfile1 extends State<ViewProfile1> {
                   )),
             ],
           ),
-        ));
+        );
   }
 }

--- a/conferecebook/lib/ViewProfile2.dart
+++ b/conferecebook/lib/ViewProfile2.dart
@@ -116,18 +116,22 @@ class _ViewProfile2 extends State<ViewProfile2> {
     image = map.values.toList()[2][userToSee]["photo"];
     name = map.values.toList()[2][userToSee]["name"];
     city = map.values.toList()[2][userToSee]["city"];
-    facebook = map.values.toList()[2][userToSee]["facebook"];
-    instagram = map.values.toList()[2][userToSee]["instagram"];
-    github = map.values.toList()[2][userToSee]["github"];
-    twitter = map.values.toList()[2][userToSee]["twitter"];
-    linkedin = map.values.toList()[2][userToSee]["linkedin"];
+    facebook = map.values.toList()[2][userToSee]["facebook"] == null ? "" : map.values.toList()[2][userToSee]["facebook"];
+    instagram = map.values.toList()[2][userToSee]["instagram"] == null ? "" : map.values.toList()[2][userToSee]["instagram"];
+    github = map.values.toList()[2][userToSee]["github"] == null ? "" : map.values.toList()[2][userToSee]["github"];
+    twitter = map.values.toList()[2][userToSee]["twitter"] == null ? "" : map.values.toList()[2][userToSee]["twitter"];
+    linkedin = map.values.toList()[2][userToSee]["linkedin"] == null ? "" : map.values.toList()[2][userToSee]["linkedin"];
     interests = map.values.toList()[2][userToSee]["interests"];
     myInterests = interests.split(',').toList();
 
     String code;
 
     return WillPopScope(
-        onWillPop: () async => false,
+        // ignore: missing_return
+        onWillPop: () {
+          Navigator.pop(context);
+          Navigator.pop(context);
+        },
         child: Scaffold(
           backgroundColor: const Color(0xffffffff),
           body: Stack(
@@ -163,21 +167,21 @@ class _ViewProfile2 extends State<ViewProfile2> {
                 child: SizedBox(
                   width: SizeConfig.screenWidth * 100.0,
                   child: Text(
-                    this.city,
+                    this.city.trimRight().isEmpty
+                        ? 'Undefined city'
+                        : this.city,
                     style: TextStyle(
-                      fontFamily: 'Roboto',
-                      fontSize: 12,
-                      color: const Color(0xff1A2677),
-                      letterSpacing: 0.1875,
-                      fontWeight: FontWeight.w500,
-                      height: 1.2,
-                    ),
+                        fontFamily: 'Roboto',
+                        fontSize: 12,
+                        color: this.city.trimRight().isEmpty
+                            ? const Color(0xffd3d3d3)
+                            : const Color(0xff1A2677)),
                     textAlign: TextAlign.center,
                   ),
                 ),
               ),
               Transform.translate(
-                offset: Offset(SizeConfig.screenWidth * 130,
+                offset: Offset(SizeConfig.screenWidth * 140,
                     SizeConfig.screenHeight * 350),
                 child: Text(
                   'Social Media',
@@ -193,7 +197,7 @@ class _ViewProfile2 extends State<ViewProfile2> {
                 ),
               ),
               Transform.translate(
-                offset: Offset(SizeConfig.screenWidth * 150,
+                offset: Offset(SizeConfig.screenWidth * 158,
                     SizeConfig.screenHeight * 550),
                 child: Text(
                   'Interests',
@@ -213,43 +217,58 @@ class _ViewProfile2 extends State<ViewProfile2> {
                       SizeConfig.screenHeight * 600),
                   child: Container(
                     width: SizeConfig.screenWidth * 250,
-                    child: Tags(
-                      key: _tagStateKey,
-                      itemCount: myInterests.length, // required
-                      itemBuilder: (int index) {
-                        final item = myInterests[index];
-                        return ItemTags(
-                          // Each ItemTags must contain a Key. Keys allow Flutter to
-                          // uniquely identify widgets.
-                          key: Key(index.toString()),
-                          index: index,
-                          // required
-                          title: item,
-                          textStyle: TextStyle(
-                            fontSize: 10,
+                    child: interests.trimRight().isEmpty
+                        ? Text(
+                            'No interest',
+                            style: TextStyle(
+                              fontFamily: 'Roboto',
+                              fontSize: 15,
+                              color: const Color(0xffd3d3d3),
+                              letterSpacing: 0.36,
+                              fontWeight: FontWeight.w500,
+                              height: 1,
+                            ),
+                            textAlign: TextAlign.center,
+                          )
+                        : Tags(
+                            key: _tagStateKey,
+                            itemCount: myInterests.length, // required
+                            itemBuilder: (int index) {
+                              final item = myInterests[index];
+                              return ItemTags(
+                                // Each ItemTags must contain a Key. Keys allow Flutter to
+                                // uniquely identify widgets.
+                                key: Key(index.toString()),
+                                index: index,
+                                // required
+                                title: item,
+                                textStyle: TextStyle(
+                                  fontSize: 10,
+                                ),
+                                combine: ItemTagsCombine.withTextBefore,
+                                image: null,
+                                // OR null,
+                                icon: null,
+                                // OR null,
+                                removeButton: null,
+                                // OR null,
+                                onPressed: (item) => print(item),
+                                onLongPressed: (item) => print(item),
+                              );
+                            },
                           ),
-                          combine: ItemTagsCombine.withTextBefore,
-                          image: null,
-                          // OR null,
-                          icon: null,
-                          // OR null,
-                          removeButton: null,
-                          // OR null,
-                          onPressed: (item) => print(item),
-                          onLongPressed: (item) => print(item),
-                        );
-                      },
-                    ),
                   )),
               Transform.translate(
-                offset: Offset(SizeConfig.screenWidth * 200,
+                offset: Offset(SizeConfig.screenWidth * 210,
                     SizeConfig.screenHeight * 440.0),
                 child: Container(
                     child: IconButton(
                         icon: Icon(FontAwesomeIcons.linkedin,
-                            color: const Color(0xff1A2677)),
+                            color: this.linkedin.isNotEmpty
+                                ? const Color(0xff1A2677)
+                                : const Color(0xffdddddd)),
                         onPressed: () async {
-                          if (this.linkedin == null)
+                          if (this.linkedin.isEmpty)
                             showAlertDialog(context, "LinkedIn");
                           else {
                             String url =
@@ -263,14 +282,16 @@ class _ViewProfile2 extends State<ViewProfile2> {
                         })),
               ),
               Transform.translate(
-                offset: Offset(SizeConfig.screenWidth * 220,
+                offset: Offset(SizeConfig.screenWidth * 230,
                     SizeConfig.screenHeight * 380.0),
                 child: Container(
                     child: IconButton(
                         icon: Icon(FontAwesomeIcons.twitter,
-                            color: const Color(0xff1A2677)),
+                            color: this.twitter.isNotEmpty
+                                ? const Color(0xff1A2677)
+                                : const Color(0xffdddddd)),
                         onPressed: () async {
-                          if (this.twitter == null)
+                          if (this.twitter.isEmpty)
                             showAlertDialog(context, "Twitter");
                           else {
                             String url = 'https://twitter.com/' + this.twitter;
@@ -283,14 +304,16 @@ class _ViewProfile2 extends State<ViewProfile2> {
                         })),
               ),
               Transform.translate(
-                offset: Offset(SizeConfig.screenWidth * 150,
+                offset: Offset(SizeConfig.screenWidth * 160,
                     SizeConfig.screenHeight * 440.0),
                 child: Container(
                     child: IconButton(
                         icon: Icon(FontAwesomeIcons.github,
-                            color: const Color(0xff1A2677)),
+                            color: this.github.isNotEmpty
+                                ? const Color(0xff1A2677)
+                                : const Color(0xffdddddd)),
                         onPressed: () async {
-                          if (this.github == null)
+                          if (this.github.isEmpty)
                             showAlertDialog(context, "Github");
                           else {
                             String url = 'https://github.com/' + this.github;
@@ -303,14 +326,16 @@ class _ViewProfile2 extends State<ViewProfile2> {
                         })),
               ),
               Transform.translate(
-                offset: Offset(SizeConfig.screenWidth * 170,
+                offset: Offset(SizeConfig.screenWidth * 180,
                     SizeConfig.screenHeight * 380.0),
                 child: Container(
                     child: IconButton(
                         icon: Icon(FontAwesomeIcons.instagram,
-                            color: const Color(0xff1A2677)),
+                            color: this.instagram.isNotEmpty
+                                ? const Color(0xff1A2677)
+                                : const Color(0xffdddddd)),
                         onPressed: () async {
-                          if (this.instagram == null)
+                          if (this.instagram.isEmpty)
                             showAlertDialog(context, "Instagram");
                           else {
                             String url =
@@ -324,14 +349,16 @@ class _ViewProfile2 extends State<ViewProfile2> {
                         })),
               ),
               Transform.translate(
-                offset: Offset(SizeConfig.screenWidth * 120,
+                offset: Offset(SizeConfig.screenWidth * 130,
                     SizeConfig.screenHeight * 380.0),
                 child: Container(
                     child: IconButton(
                         icon: Icon(FontAwesomeIcons.facebook,
-                            color: const Color(0xff1A2677)),
+                            color: this.facebook.isNotEmpty
+                                ? const Color(0xff1A2677)
+                                : const Color(0xffdddddd)),
                         onPressed: () async {
-                          if (this.facebook == null)
+                          if (this.facebook.isEmpty)
                             showAlertDialog(context, "Facebook");
                           else {
                             String url =
@@ -425,58 +452,11 @@ class _ViewProfile2 extends State<ViewProfile2> {
                         child: InkWell(
                           splashColor: const Color(0xff1A2677), // splash color
                           onTap: () async {
-                            FirebaseDatabase.instance
-                                .reference()
-                                .once()
-                                .then((DataSnapshot snapshot) {
-                              Map<dynamic, dynamic> map = snapshot.value;
-                              Navigator.of(context)
-                                  .pushReplacement(MaterialPageRoute(
-                                      builder: (context) => ParticipantsList(
-                                            auth: widget.auth,
-                                            code: widget.code,
-                                            map: map,
-                                            attendeeFilter: true,
-                                            speakerFilter: true,
-                                            sponsorFilter: true,
-                                            organizerFilter: true,
-                                          )));
-                            });
+                            Navigator.of(context).pop();
+                            Navigator.of(context).pop();
                           }, // button pressed
                           child: Icon(
-                            FontAwesomeIcons.users,
-                            color: Colors.white,
-                          ), // icon
-                        ),
-                      ),
-                    ),
-                  )),
-              Transform.translate(
-                  offset: Offset(SizeConfig.screenWidth * 340,
-                      SizeConfig.screenHeight * 20 + 20),
-                  child: SizedBox.fromSize(
-                    size: Size(56, 56), // button width and height
-                    child: ClipOval(
-                      child: Material(
-                        color: const Color(0xff1A2677), // button color
-                        child: InkWell(
-                          splashColor: const Color(0xff1A2677), // splash color
-                          onTap: () async {
-                            FirebaseDatabase.instance
-                                .reference()
-                                .once()
-                                .then((DataSnapshot snapshot) {
-                              Map<dynamic, dynamic> map = snapshot.value;
-                              Navigator.of(context).pushReplacement(
-                                  MaterialPageRoute(
-                                      builder: (context) => HomeFeed(
-                                          auth: widget.auth,
-                                          code: widget.code,
-                                          map: map)));
-                            });
-                          }, // button pressed
-                          child: Icon(
-                            FontAwesomeIcons.home,
+                            FontAwesomeIcons.arrowLeft,
                             color: Colors.white,
                           ), // icon
                         ),

--- a/conferecebook/pubspec.lock
+++ b/conferecebook/pubspec.lock
@@ -28,42 +28,42 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0-nullsafety.2"
+    version: "2.5.0-nullsafety.1"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.2"
+    version: "2.1.0-nullsafety.1"
   characters:
     dependency: transitive
     description:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.4"
+    version: "1.1.0-nullsafety.3"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.2"
+    version: "1.2.0-nullsafety.1"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.2"
+    version: "1.1.0-nullsafety.1"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0-nullsafety.4"
+    version: "1.15.0-nullsafety.3"
   convert:
     dependency: transitive
     description:
@@ -78,6 +78,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.5"
+  csslib:
+    dependency: transitive
+    description:
+      name: csslib
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.16.2"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -91,7 +98,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.2"
+    version: "1.2.0-nullsafety.1"
   ffi:
     dependency: transitive
     description:
@@ -181,6 +188,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_html:
+    dependency: "direct main"
+    description:
+      name: flutter_html
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.11.1"
   flutter_launcher_icons:
     dependency: "direct main"
     description:
@@ -240,6 +254,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "8.10.1"
+  html:
+    dependency: transitive
+    description:
+      name: html
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.14.0+4"
   http:
     dependency: "direct main"
     description:
@@ -302,7 +323,7 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10-nullsafety.2"
+    version: "0.12.10-nullsafety.1"
   material_tag_editor:
     dependency: "direct main"
     description:
@@ -316,7 +337,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.5"
+    version: "1.3.0-nullsafety.3"
   page_transition:
     dependency: "direct main"
     description:
@@ -330,7 +351,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.2"
+    version: "1.8.0-nullsafety.1"
   path_drawing:
     dependency: transitive
     description:
@@ -433,7 +454,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.3"
+    version: "1.8.0-nullsafety.2"
   splashscreen:
     dependency: "direct main"
     description:
@@ -447,42 +468,42 @@ packages:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.0-nullsafety.5"
+    version: "1.10.0-nullsafety.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.2"
+    version: "2.1.0-nullsafety.1"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.2"
+    version: "1.1.0-nullsafety.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.2"
+    version: "1.2.0-nullsafety.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19-nullsafety.4"
+    version: "0.2.19-nullsafety.2"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.4"
+    version: "1.3.0-nullsafety.3"
   url_launcher:
     dependency: "direct main"
     description:
@@ -531,7 +552,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.4"
+    version: "2.1.0-nullsafety.3"
   video_player:
     dependency: "direct main"
     description:
@@ -582,5 +603,5 @@ packages:
     source: hosted
     version: "2.2.1"
 sdks:
-  dart: ">=2.11.0-0.0 <=2.12.0-3.0.dev"
+  dart: ">=2.10.0-110 <2.11.0"
   flutter: ">=1.22.0 <2.0.0"

--- a/conferecebook/pubspec.yaml
+++ b/conferecebook/pubspec.yaml
@@ -25,6 +25,7 @@ dependencies:
     sdk: flutter
   firebase_core: ^0.5.1  # add dependency for Firebase Core
   firebase_database: any
+  flutter_html: any
   firebase_storage : any
   firebase_auth: ^0.18.2
   adobe_xd: ^1.0.0+1


### PR DESCRIPTION
- Ao ver um perfil, já há um botão para voltar ao ecrã anterior (ou através do Android back button).

- Ao personalizar a conference history (oculto ou não), a opção de oculto aquando a mudança de posição do botão diz agora "Blocked" em vez do anterior "No".

- Na edição do perfil, foram alinhados os campos de texto.

- No MyProfile tem uma seta para a direita. Aquando da seleção da mesma, a aplicação parava devido a um erro com as redes sociais. O erro foi corrigido, assim como a questão da cor aparecer a cinza ou azul quando a rede social está ou não definida.

- Nas "Moderation Settings", o "No" foi substituído por "Blocked".

- Ao selecionar a opção "Enter Event Code" no sidemenu, ao voltar atrás, volta para o ecrã anterior e não para a lista de eventos.

- O primeiro ecrã de Create Account tem agora os elementos com o mesmo posicionamento do ecrã de login, apresentando uma transição suave entre ambos.

- O espaçamento que existia entre o Create Account e o ConferenceBook no Login foi agora eliminado devido a inserção do "Reset Password"

- O utilizador pode agora fazer reset à password, indicando o seu e-mail (há uma verificação da existência) e recebe assim um mail com um link para redefinir a password.

- O feedback visual não era o melhor quer no MyProfile, quer no ViewProfile e no EditProfile no que toca a campos de dados sem informação. Em vez de aparecem sem qualquer conteúdo e com uma caixa que parecia que o ecrã ainda estava em construção, aparece agora um texto que diz "Write you info here", onde info varia com o campo (EditProfile) ou um texto que diz "Undefined info" ou "No info", onde info varia com o campo (MyProfile e ViewProfile). As caixas de edição de texto no EditProfile foram redesenhadas e foi-lhes adicionado um ícone. 

- A data dos posts e dos comentários foi escurecida para ter mais contraste.

- A border-radius do container de um post foi reduzida para metade. 

- O número de comentários foi aproximado mais um pouco do respetivo ícone

- Foi adicionada uma margem maior no topo e direita do avatar e do nome no container de um post

- No signup, exige-se que o utilizador defina um nome. No entanto, tal não estava a ser feito quando o mesmo edita o perfil. A verificação foi assim adicionada.

- Ao clicar num perfil (a partir de um post, comentário ou lista de participantes), se for o perfil do utilizador com login feito, em vez de ir para o ViewProfile, vai para o MyProfile.

- O display da cidade estava diferente entre o ViewProfile 1 e 2 e o mesmo sucedia no MyProfile 1 e 2. Corrigido.

- Alinhamento do ícone de eliminar um post com a linha do nome e do avatar. O alinhamento do mesmo ícone para os comentários ficou à direita do comentário, dado que como estava fazia com que as datas dos comentários não ficassem alinhadas.

- Já é possível reproduzir vídeos!!!